### PR TITLE
Merge Voucher v2.5.2 into grafeas/Voucher

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -19,6 +19,7 @@ var ErrNoAuth = errors.New("no configured Auth")
 type Auth interface {
 	GetTokenSource(context.Context, reference.Named) (oauth2.TokenSource, error)
 	ToClient(ctx context.Context, image reference.Named) (*http.Client, error)
+	IsForDomain(url reference.Named) bool
 }
 
 // AuthToClient takes a struct implementing Auth and returns a new http.Client

--- a/auth/error.go
+++ b/auth/error.go
@@ -1,0 +1,23 @@
+package auth
+
+import (
+	"fmt"
+
+	"github.com/docker/distribution/reference"
+)
+
+// AuthError is the error returned when authenticating while pulling manifests connecting to protected systems
+type AuthError struct {
+	Reason    string
+	ImageName reference.Named
+}
+
+// Error returns a string for logging purposes
+func (e *AuthError) Error() string {
+	return fmt.Sprintf("auth failed: %s for %s", e.Reason, e.ImageName)
+}
+
+// NewAuthError returns an AuthError struct with the reason for erroring, as well as the Name of the image reference
+func NewAuthError(reason string, imageName reference.Named) error {
+	return &AuthError{reason, imageName}
+}

--- a/auth/google/auth.go
+++ b/auth/google/auth.go
@@ -34,6 +34,10 @@ func (a *gAuth) GetTokenSource(ctx context.Context, ref reference.Named) (oauth2
 // ToClient returns a new http.Client with the authentication details setup by
 // Auth.GetTokenSource.
 func (a *gAuth) ToClient(ctx context.Context, image reference.Named) (*http.Client, error) {
+	if !a.IsForDomain(image) {
+		return nil, auth.NewAuthError("does not match domain", image)
+	}
+
 	tokenSource, err := a.GetTokenSource(ctx, image)
 	if nil != err {
 		return nil, err
@@ -43,6 +47,11 @@ func (a *gAuth) ToClient(ctx context.Context, image reference.Named) (*http.Clie
 	err = auth.UpdateIdleConnectionsTimeout(client)
 
 	return client, err
+}
+
+// IsForDomain validates the domain part of the Named image reference
+func (a *gAuth) IsForDomain(image reference.Named) bool {
+	return "gcr.io" == reference.Domain(image)
 }
 
 // NewAuth returns a new voucher.Auth to access Google specific resources.

--- a/checks/nobody/check.go
+++ b/checks/nobody/check.go
@@ -32,6 +32,7 @@ func (n *check) Check(ctx context.Context, i voucher.ImageData) (bool, error) {
 	}
 
 	imageConfig, err := docker.RequestImageConfig(client, i)
+
 	if nil != err {
 		return false, err
 	}

--- a/checks/nobody/check_test.go
+++ b/checks/nobody/check_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/docker/distribution/reference"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -24,6 +25,28 @@ func TestNobodyCheck(t *testing.T) {
 	pass, err := nobodyCheck.Check(context.Background(), i)
 
 	require.NoErrorf(t, err, "check failed with error: %s", err)
+	assert.True(t, pass, "check failed when it should have passed")
+}
+
+func TestThirdPartyImage(t *testing.T) {
+	server := vtesting.NewTestDockerServer(t)
+
+	auth := vtesting.NewAuth(server)
+
+	name := "registry-1.docker.io/library/alpine@sha256:4e01ddea8def856ba9fee17668fa0b2e45a8bc78127b7ab6cf921f6d6fd86ac9"
+	ref, err := reference.Parse(name)
+	require.NoErrorf(t, err, "could not make image reference (\"%s\"): %s", name, err)
+
+	refCanonical, ok := ref.(reference.Canonical)
+	require.True(t, ok, "could not convert reference to Canonical reference")
+
+	nobodyCheck := new(check)
+	nobodyCheck.SetAuth(auth)
+
+	pass, err := nobodyCheck.Check(context.Background(), refCanonical)
+
+	require.Error(t, err, "check should have failed with error, but didn't")
+	assert.Contains(t, err.Error(), "auth failed: does not match domain", "check should have failed due to invalid image reference domain, but didn't")
 	assert.False(t, pass, "check passed when it should have failed")
 }
 
@@ -36,4 +59,20 @@ func TestNobodyCheckWithNoAuth(t *testing.T) {
 	pass, err := nobodyCheck.Check(context.Background(), i)
 	require.Equal(t, err, voucher.ErrNoAuth, "check should have failed due to lack of Auth, but didn't")
 	assert.False(t, pass, "check passed when it should have failed due to no Auth")
+}
+
+func TestFailingNobodyCheck(t *testing.T) {
+	server := vtesting.NewTestDockerServer(t)
+
+	auth := vtesting.NewAuth(server)
+
+	i := vtesting.NewNobodyBadTestReference(t)
+
+	nobodyCheck := new(check)
+	nobodyCheck.SetAuth(auth)
+
+	pass, err := nobodyCheck.Check(context.Background(), i)
+
+	require.NoError(t, err, "check should have failed with error, but didn't")
+	assert.False(t, pass, "check passed when it should have failed")
 }

--- a/cmd/config/metadataclient.go
+++ b/cmd/config/metadataclient.go
@@ -38,12 +38,15 @@ func NewMetadataClient(ctx context.Context, secrets *Secrets) (voucher.MetadataC
 		log.Printf("signer %q is unknown, supported values are 'kms' or 'pgp'\n", signerName)
 	}
 
+	if viper.GetString("image_project") != "" {
+		log.Warning("`image_project` is deprecated. Please rely on the `valid_repos` configuration option to limit where images come from.")
+	}
+
 	metadataClient := viper.GetString("metadata_client")
 	switch metadataClient {
 	case "containeranalysis":
 		return containeranalysis.NewClient(
 			ctx,
-			viper.GetString("image_project"),
 			viper.GetString("binauth_project"),
 			keyring,
 		)
@@ -51,7 +54,6 @@ func NewMetadataClient(ctx context.Context, secrets *Secrets) (voucher.MetadataC
 		log.Warning("`metadata_client` option is not set, defaulting to \"containeranalysis\"")
 		return containeranalysis.NewClient(
 			ctx,
-			viper.GetString("image_project"),
 			viper.GetString("binauth_project"),
 			keyring,
 		)

--- a/cmd/voucher_client/digest.go
+++ b/cmd/voucher_client/digest.go
@@ -27,7 +27,7 @@ func getCanonicalReference(client *http.Client, ref reference.Reference) (refere
 		if nil != err {
 			return nil, fmt.Errorf("getting digest from tag failed: %s", err)
 		}
-		canonicalRef, err := reference.WithDigest(taggedRef, imageDigest)
+		canonicalRef, err := reference.WithDigest(reference.TrimNamed(taggedRef), imageDigest)
 		if nil != err {
 			return nil, fmt.Errorf("making canonical reference failed: %s", err)
 		}

--- a/cmd/voucher_server/README.md
+++ b/cmd/voucher_server/README.md
@@ -45,7 +45,6 @@ Below are the configuration options for Voucher Server:
 |                      | `valid_repos`                | A list of repos that are owned by your team/organization.                                             |
 |                      | `trusted_builder_identities` | A list of email addresses. Owners of these emails are considered "trusted" (and will pass Provenance) |
 |                      | `trusted_projects`           | A list of projects that are considered "trusted" (and will pass Provenance)                           |
-|                      | `image_project`              | The project in the metadata server that image information is stored.                                  |
 |                      | `binauth_project`            | The project in the metadata server that the binauth information is stored.                            |
 | `checks`             | (test name here)             | A test that is active when running "all" tests.                                                       |
 | `server`             | `port`                       | The port that the server can be reached on.                                                           |

--- a/cmd/voucher_server/README.md
+++ b/cmd/voucher_server/README.md
@@ -40,7 +40,7 @@ Below are the configuration options for Voucher Server:
 | Group                | Key                          | Description                                                                                           |
 | :-------------       | :--------------------------- | :---------------------------------------------------------------------------------------------------- |
 |                      | `dryrun`                     | When set, don't create attestations.                                                                  |
-|                      | `scanner`                    | The vulnerability scanner to use ("clair" or "gca").                                                  |
+|                      | `scanner`                    | The vulnerability scanner to use ("clair" or "metadata").                                                  |
 |                      | `failon`                     | The minimum vulnerability to fail on. Discussed below.                                                |
 |                      | `valid_repos`                | A list of repos that are owned by your team/organization.                                             |
 |                      | `trusted_builder_identities` | A list of email addresses. Owners of these emails are considered "trusted" (and will pass Provenance) |
@@ -70,7 +70,7 @@ The `scanner` option in the configuration is used to select the Vulnerability sc
 This option supports two values:
 
 - `c` or `clair` to use an instance of CoreOS's Clair.
-- `g` or `gca` to use Google Container Analysis.
+- `metadata` to use Google Container Analysis. (Note that `g` and `gca` are being deprecated in favor of `metadata`.)
 
 If you decide to use Clair, you will need to update the clair configuration block to specify the correct address for the server.
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -2,7 +2,7 @@ dryrun = false
 scanner = "metadata"
 failon = "high"
 metadata_client = "containeranalysis"
-image_project = "your-project-here"
+
 binauth_project = "your-project-here"
 signer = "kms"
 valid_repos = [

--- a/containeranalysis/containeranalysis_test.go
+++ b/containeranalysis/containeranalysis_test.go
@@ -9,12 +9,12 @@ import (
 	"github.com/Shopify/voucher"
 )
 
-const testHostname = "gcr.io/alpine/alpine@sha256:297524b7375fbf09b3784f0bbd9cb2505700dd05e03ce5f5e6d262bf2f5ac51c"
+const testImageName = "gcr.io/alpine/alpine@sha256:297524b7375fbf09b3784f0bbd9cb2505700dd05e03ce5f5e6d262bf2f5ac51c"
 
-const testResourceAddress = "resourceUrl=\"https://" + testHostname + "\""
+const testResourceAddress = "resourceUrl=\"https://" + testImageName + "\""
 
 func TestGrafeasHelperFunctions(t *testing.T) {
-	imageData, err := voucher.NewImageData(testHostname)
+	imageData, err := voucher.NewImageData(testImageName)
 	require.NoError(t, err)
 	assert.Equal(t, resourceURL(imageData), testResourceAddress)
 }

--- a/docker/config_test.go
+++ b/docker/config_test.go
@@ -16,5 +16,5 @@ func TestRequestConfig(t *testing.T) {
 
 	config, err := RequestImageConfig(client, ref)
 	require.NoError(t, err)
-	require.True(t, config.RunsAsRoot())
+	require.False(t, config.RunsAsRoot())
 }

--- a/docker/schema2/config_test.go
+++ b/docker/schema2/config_test.go
@@ -22,7 +22,7 @@ func TestRequestConfig(t *testing.T) {
 	require.NoError(t, err, "failed to get config: %s", err)
 
 	expectedConfig := &dockerTypes.ExecConfig{
-		User: "root",
+		User: "nobody",
 	}
 
 	assert.Equal(t, expectedConfig, config)

--- a/docker/uri/project.go
+++ b/docker/uri/project.go
@@ -1,0 +1,34 @@
+package uri
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/docker/distribution/reference"
+)
+
+type ErrNoProjectInReference struct {
+	ref reference.Reference
+}
+
+func (err *ErrNoProjectInReference) Error() string {
+	return fmt.Sprintf("could not find project path in reference \"%s\"", err.ref)
+}
+
+// ReferenceToProjectName returns what should be the GCR project name for an
+// image reference.
+//
+// For example, if an image is in the project "my-cool-project" the image path
+// should start with `gcr.io/my-cool-project`.
+func ReferenceToProjectName(ref reference.Reference) (string, error) {
+	values := strings.Split(ref.String(), "/")
+	if 2 < len(values) {
+		if values[0] == "gcr.io" {
+			return values[1], nil
+		}
+	}
+
+	return "", &ErrNoProjectInReference{
+		ref: ref,
+	}
+}

--- a/docker/uri/project_test.go
+++ b/docker/uri/project_test.go
@@ -1,0 +1,30 @@
+package uri
+
+import (
+	"testing"
+
+	"github.com/docker/distribution/reference"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const testImageReference = "gcr.io/alpine/alpine@sha256:297524b7375fbf09b3784f0bbd9cb2505700dd05e03ce5f5e6d262bf2f5ac51c"
+
+func TestReferenceToProjectName(t *testing.T) {
+	ref, err := reference.Parse(testImageReference)
+	require.NoError(t, err)
+
+	project, err := ReferenceToProjectName(ref)
+	assert.NoError(t, err)
+	assert.Equal(t, "alpine", project)
+}
+
+func TestReferenceToProjectNameWithOtherReference(t *testing.T) {
+	ref, err := reference.Parse("alpine/alpine")
+
+	require.NoError(t, err)
+
+	project, err := ReferenceToProjectName(ref)
+	assert.Error(t, err)
+	assert.Equal(t, "", project)
+}

--- a/metrics/dogstatsd.go
+++ b/metrics/dogstatsd.go
@@ -23,6 +23,10 @@ func NewDogStatsdClient(addr string, samplingRate float64, tags []string) (*DogS
 	}, nil
 }
 
+func (d *DogStatsdClient) CheckRunStart(check string) {
+	_ = d.client.Incr("voucher.check.run.start", []string{"check:" + check}, d.samplingRate)
+}
+
 func (d *DogStatsdClient) CheckRunLatency(check string, dur time.Duration) {
 	_ = d.client.Timing("voucher.check.run.latency", dur, []string{"check:" + check}, d.samplingRate)
 }
@@ -31,14 +35,36 @@ func (d *DogStatsdClient) CheckAttestationLatency(check string, dur time.Duratio
 	_ = d.client.Timing("voucher.check.attestation.latency", dur, []string{"check:" + check}, d.samplingRate)
 }
 
-func (d *DogStatsdClient) CheckRunError(check string) {
+func (d *DogStatsdClient) CheckRunError(check string, err error) {
 	_ = d.client.Incr("voucher.check.run.error", []string{"check:" + check}, d.samplingRate)
+	_ = d.client.Event(createDataDogErrorEvent(check, "Voucher Check Run Error", err))
 }
 
 func (d *DogStatsdClient) CheckRunFailure(check string) {
 	_ = d.client.Incr("voucher.check.run.failure", []string{"check:" + check}, d.samplingRate)
 }
 
-func (d *DogStatsdClient) CheckAttestationError(check string) {
+func (d *DogStatsdClient) CheckRunSuccess(check string) {
+	_ = d.client.Incr("voucher.check.run.success", []string{"check:" + check}, d.samplingRate)
+}
+
+func (d *DogStatsdClient) CheckAttestationStart(check string) {
+	_ = d.client.Incr("voucher.check.attestation.start", []string{"check:" + check}, d.samplingRate)
+}
+
+func (d *DogStatsdClient) CheckAttestationSuccess(check string) {
+	_ = d.client.Incr("voucher.check.attestation.success", []string{"check:" + check}, d.samplingRate)
+}
+
+func (d *DogStatsdClient) CheckAttestationError(check string, err error) {
 	_ = d.client.Incr("voucher.check.attestation.error", []string{"check:" + check}, d.samplingRate)
+	_ = d.client.Event(createDataDogErrorEvent(check, "Voucher Check Attestation Error", err))
+}
+
+func createDataDogErrorEvent(check, title string, err error) *statsd.Event {
+	event := statsd.NewEvent(title, err.Error())
+	event.AlertType = statsd.Error
+	event.Priority = statsd.Low
+	event.Tags = []string{"check:" + check}
+	return event
 }

--- a/metrics/metrics.go
+++ b/metrics/metrics.go
@@ -5,9 +5,13 @@ import (
 )
 
 type Client interface {
+	CheckRunStart(string)
 	CheckRunLatency(string, time.Duration)
 	CheckAttestationLatency(string, time.Duration)
 	CheckRunFailure(string)
-	CheckRunError(string)
-	CheckAttestationError(string)
+	CheckRunError(string, error)
+	CheckRunSuccess(string)
+	CheckAttestationStart(string)
+	CheckAttestationError(string, error)
+	CheckAttestationSuccess(string)
 }

--- a/metrics/noop_client.go
+++ b/metrics/noop_client.go
@@ -6,8 +6,12 @@ import (
 
 type NoopClient struct{}
 
+func (*NoopClient) CheckRunStart(string)                          {}
 func (*NoopClient) CheckRunLatency(string, time.Duration)         {}
 func (*NoopClient) CheckAttestationLatency(string, time.Duration) {}
 func (*NoopClient) CheckRunFailure(string)                        {}
-func (*NoopClient) CheckRunError(string)                          {}
-func (*NoopClient) CheckAttestationError(string)                  {}
+func (*NoopClient) CheckRunError(string, error)                   {}
+func (*NoopClient) CheckRunSuccess(string)                        {}
+func (*NoopClient) CheckAttestationStart(string)                  {}
+func (*NoopClient) CheckAttestationError(string, error)           {}
+func (*NoopClient) CheckAttestationSuccess(string)                {}

--- a/testdata/config.toml
+++ b/testdata/config.toml
@@ -1,7 +1,6 @@
 dryrun          = true
 scanner         = "clair"
 failon          = "high"
-image_project   = "voucher-test-project"
 binauth_project = "voucher-binauth"
 metadata_client = "containeranalysis"
 

--- a/testing/manifests.go
+++ b/testing/manifests.go
@@ -45,6 +45,44 @@ func NewTestManifest() *schema2.DeserializedManifest {
 	return newManifest
 }
 
+// NewTestRootManifest creates a test schema2 manifest for our mock Docker API, which points to an image whose user is configured to be root
+func NewTestRootManifest() *schema2.DeserializedManifest {
+	manifest := schema2.Manifest{
+		Config: distribution.Descriptor{
+			MediaType: schema2.MediaTypeImageConfig,
+			Size:      7023,
+			Digest:    "sha256:b5b2b2c507a0944348e0303114d8d93bbbb081732b86451d9bce1f432a537bc7",
+		},
+		Layers: []distribution.Descriptor{
+			{
+				MediaType: schema2.MediaTypeLayer,
+				Size:      32654,
+				Digest:    "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+			},
+			{
+				MediaType: schema2.MediaTypeLayer,
+				Size:      16724,
+				Digest:    "sha256:3c3a4604a545cdc127456d94e421cd355bca5b528f4a9c1905b15da2eb4a4c6b",
+			},
+			{
+				MediaType: schema2.MediaTypeLayer,
+				Size:      73109,
+				Digest:    "sha256:ec4b8955958665577945c89419d1af06b5f7636b4ac3da7f12184802ad867736",
+			},
+		},
+	}
+
+	manifest.SchemaVersion = 2
+	manifest.MediaType = schema2.MediaTypeManifest
+
+	newManifest, err := schema2.FromStruct(manifest)
+	if nil != err {
+		panic("failed to generate new schema2 manifest")
+	}
+
+	return newManifest
+}
+
 // NewTestSchema1Manifest creates a test schema1 manifest for our mock Docker API.
 func NewTestSchema1Manifest() schema1.Manifest {
 	manifest := schema1.Manifest{

--- a/testing/reference.go
+++ b/testing/reference.go
@@ -25,6 +25,15 @@ func NewBadTestReference(t *testing.T) reference.Canonical {
 	return parseReference(t, "localhost/path/to/bad/image@sha256:bad8c8af52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da")
 }
 
+// NewNobodyBadTestReference creates a new reference to be used for the nobody check.
+// The returned reference is assumed to not, and does not have valid configuration
+// or layers.
+func NewNobodyBadTestReference(t *testing.T) reference.Canonical {
+	t.Helper()
+
+	return parseReference(t, "localhost/path/to/image@sha256:b248c8af52ba402ed7dd98d73f5a41836ece508d1f4704b274562ac0c9b3b7da")
+}
+
 // NewRateLimitedTestReference creates a new reference to be used to test
 // the handling of Rate Limited docker calls.
 // The returned response from calling this reference cannot be parsed by a


### PR DESCRIPTION
This PR, assuming I've done it correctly, will merge the changes added in Voucher v2.5.2 to the grafeas version of Voucher.

Thes changes include:

* support for multiple image projects
* better metrics